### PR TITLE
Convert complexdeployment to GitHub Actions

### DIFF
--- a/.github/workflows/complexdeployment_production.yml
+++ b/.github/workflows/complexdeployment_production.yml
@@ -1,0 +1,27 @@
+name: complexdeployment_production
+on:
+#   # This item has no matching transformer
+#   environment-success:
+#     environment: Staging
+  schedule:
+  - cron: 0 0 * * *
+env:
+  quickCompileMavenGoals_experimental: '1'
+  password: "${{ secrets.password }}"
+  username: admin
+jobs:
+  Production:
+    runs-on: ubuntu-latest
+    env:
+      variableName: variableValue
+    steps:
+    - name: Clean working directory
+      run: rm -rf ${{ github.workspace }}/*
+      shell: bash
+    - uses: actions/download-artifact@v3.0.1
+      with:
+        name: IN-COM_Binaries
+        path: "/workdir"
+    - run: |-
+        echo 'hello world'
+        echo "I’m done"

--- a/.github/workflows/complexdeployment_qa.yml
+++ b/.github/workflows/complexdeployment_qa.yml
@@ -1,0 +1,48 @@
+name: complexdeployment_qa
+on:
+  repository_dispatch:
+#   # This item has no matching transformer
+#   stage-success:
+#     stage: Deploy
+#     branch: branch_PAN-GIT-JOB1-6
+  schedule:
+  - cron: 0 0 * * *
+env:
+  quickCompileMavenGoals_experimental: '1'
+  password: "${{ secrets.password }}"
+  username: admin
+jobs:
+  QA:
+    runs-on:
+      - self-hosted
+      - isDragonLazy
+    container:
+      image: docker-image-name
+    env:
+      variableName: variableValue
+    steps:
+    - name: Clean working directory
+      run: rm -rf ${{ github.workspace }}/*
+      shell: bash
+    # warning: This will download all available artifacts, ensure this is the correct behavior.
+    - uses: actions/download-artifact@v3.0.1
+      with:
+        path: "/workdir"
+    - run: |-
+        echo 'hello world'
+        echo "I'm done"
+    - uses: actions/download-artifact@v3.0.1
+      with:
+        name: IN-COM_my-artifacts
+        path: "/my-artifacts"
+    - run: echo "let's clean it up"
+      if: always()
+    - uses: actions/download-artifact@v3.0.1
+      with:
+        name: IN-COM_All
+      if: always()
+    - uses: actions/download-artifact@v3.0.1
+      with:
+        name: IN-COM_my-artifacts
+        path: "/my-artifacts"
+      if: always()

--- a/.github/workflows/complexdeployment_staging.yml
+++ b/.github/workflows/complexdeployment_staging.yml
@@ -1,0 +1,40 @@
+name: complexdeployment_staging
+on:
+#   # This item has no matching transformer
+#   stage-success:
+#     stage: Deploy
+#     branch: branch_PAN-GIT-JOB1-6
+#     description: unicorn
+  repository_dispatch:
+#   # This item has no matching transformer
+#   environment-success:
+#     environment: QA
+#   # This item has no matching transformer
+#     environment: Production
+env:
+  quickCompileMavenGoals_experimental: '1'
+  password: "${{ secrets.password }}"
+  username: admin
+jobs:
+  Staging:
+    runs-on: ubuntu-latest
+    container:
+      image: docker-image-name
+      volumes:
+      - "${{ env.working_directory }}:${{ env.working_directory }}"
+      - "${{ env.tmp_directory }}:${{ env.tmp_directory }}"
+    env:
+      variableName: variableValue
+    steps:
+    - name: Clean working directory
+      run: rm -rf ${{ github.workspace }}/*
+      shell: bash
+    # warning: This will download all available artifacts, ensure this is the correct behavior.
+    - uses: actions/download-artifact@v3.0.1
+      with:
+        path: "/workdir"
+    - run: |-
+        echo 'hello world'
+        echo "I'm done"
+    # warning: This will download all available artifacts, ensure this is the correct behavior.
+    - uses: actions/download-artifact@v3.0.1


### PR DESCRIPTION
Pipeline migrated from [Bamboo](https://bamboo-chicken.westus2.cloudapp.azure.com) :tada:

## Manual steps

Perform the following steps to complete the migration:

### complexdeployment_qa
- [ ] Ensure: Ensure that the corresponding Bamboo build plan is converted into a GitHub Action workflow.
Insert the following as the last step of the last job:
name: trigger dependent workflows
env:
  GH_TOKEN: "${{ github.token }}"
run: gh workflow run complexdeployment --repo ${{ github.repository }}
- [ ] Ensure a runner with the following labels exists: isDragonLazy
- [ ] Ensure secret is available: `${{ secrets.password }}`

### complexdeployment_staging
- [ ] Ensure: Ensure that the corresponding Bamboo build plan is converted into a GitHub Action workflow.
Insert the following as the last step of the last job:
name: trigger dependent workflows
if: github.ref_name == branch_PAN-GIT-JOB1-6
env:
  GH_TOKEN: "${{ github.token }}"
run: gh workflow run complexdeployment --repo ${{ github.repository }}
- [ ] Ensure secret is available: `${{ secrets.password }}`

### complexdeployment_production
- [ ] Ensure secret is available: `${{ secrets.password }}`